### PR TITLE
Export more symbols from validators contract

### DIFF
--- a/validators/Cargo.toml
+++ b/validators/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 bundlr-contracts-shared = { path = "../shared" }

--- a/validators/src/actions/slashing.rs
+++ b/validators/src/actions/slashing.rs
@@ -12,15 +12,15 @@ use bundlr_contracts_shared::{u128_utils, Address, Amount, TransactionId};
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Proposal {
-    id: String,
-    size: usize,
+    pub id: String,
+    pub size: usize,
     #[serde(with = "u128_utils")]
-    fee: u128,
-    currency: String,
+    pub fee: u128,
+    pub currency: String,
     #[serde(with = "u128_utils")]
-    block: u128,
-    validator: String,
-    signature: String,
+    pub block: u128,
+    pub validator: String,
+    pub signature: String,
 }
 
 pub type Stake = Amount;

--- a/validators/src/lib.rs
+++ b/validators/src/lib.rs
@@ -5,3 +5,8 @@ pub mod contract_utils;
 mod epoch;
 mod error;
 mod state;
+
+pub use actions::slashing;
+pub use bundlr_contracts_shared::{Address, Amount};
+pub use epoch::Epoch;
+pub use state::{State, Validator};


### PR DESCRIPTION
Export symbols so that the validator app code can use them without duplicating locally.