### PR TITLE
Fix: allow building contracts without wasm-bindgen dependency

### DIFF
--- a/bundlers/Cargo.toml
+++ b/bundlers/Cargo.toml
@@ -8,12 +8,16 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm-bindgen = { version = "= 0.2.79", features = ["serde-serialize"] }
-wasm-bindgen-futures = { version = "0.4.29" }
+bundlr-contracts-shared = { path = "../shared" }
+js-sys = { version = "0.3.56", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-js-sys = "0.3.56"
-bundlr-contracts-shared = { path = "../shared" }
+wasm-bindgen = { version = "= 0.2.79", features = ["serde-serialize"], optional = true }
+wasm-bindgen-futures = { version = "0.4.29", optional = true }
+
+[features]
+default = ["js-runtime"]
+js-runtime = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "bundlr-contracts-shared/js-runtime"]
 
 [package.metadata.wasm-pack.profile.profiling.wasm-bindgen]
 demangle-name-section = false

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -4,7 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-js-sys = "0.3.56"
+js-sys = { version = "0.3.56", optional = true }
 serde = { version = "1", features = ["derive"] }
-wasm-bindgen = { version = "= 0.2.79", features = ["serde-serialize"] }
-wasm-bindgen-futures = { version = "0.4.29" }
+wasm-bindgen = { version = "= 0.2.79", features = ["serde-serialize"], optional = true }
+wasm-bindgen-futures = { version = "0.4.29", optional = true }
+
+[features]
+default = []
+js-runtime = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures"]

--- a/shared/src/contract_utils/mod.rs
+++ b/shared/src/contract_utils/mod.rs
@@ -1,2 +1,4 @@
+#[cfg(feature = "js-runtime")]
 pub mod foreign_call;
+#[cfg(feature = "js-runtime")]
 pub mod js_imports;

--- a/token/Cargo.toml
+++ b/token/Cargo.toml
@@ -9,11 +9,15 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bundlr-contracts-shared = { path = "../shared" }
-js-sys = "0.3.56"
+js-sys = { version = "0.3.56", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-wasm-bindgen = { version = "= 0.2.79", features = ["serde-serialize"] }
-wasm-bindgen-futures = { version = "0.4.29" }
+wasm-bindgen = { version = "= 0.2.79", features = ["serde-serialize"], optional = true }
+wasm-bindgen-futures = { version = "0.4.29", optional = true }
+
+[features]
+default = ["js-runtime"]
+js-runtime = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "bundlr-contracts-shared/js-runtime"]
 
 [package.metadata.wasm-pack.profile.profiling.wasm-bindgen]
 demangle-name-section = false

--- a/token/src/contract_utils/entrypoint.rs
+++ b/token/src/contract_utils/entrypoint.rs
@@ -5,6 +5,7 @@
 use std::cell::RefCell;
 
 use serde_json::Error;
+
 use wasm_bindgen::prelude::*;
 
 use crate::action::{Action, QueryResponseMsg};

--- a/token/src/contract_utils/mod.rs
+++ b/token/src/contract_utils/mod.rs
@@ -2,6 +2,8 @@
 /////////////// DO NOT MODIFY THIS FILE /////////////
 /////////////////////////////////////////////////////
 
+#[cfg(feature = "js-runtime")]
 pub mod entrypoint;
 pub mod handler_result;
+#[cfg(feature = "js-runtime")]
 pub mod js_imports;

--- a/validators/Cargo.toml
+++ b/validators/Cargo.toml
@@ -9,13 +9,17 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 bundlr-contracts-shared = { path = "../shared" }
 data-encoding = { version = "2.3.2" }
-js-sys = "0.3.56"
+js-sys = { version = "0.3.56", optional = true }
 rand_xoshiro = "0.6.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = { version = "2", features = ["serde"] }
-wasm-bindgen = { version = "= 0.2.79", features = ["serde-serialize"] }
-wasm-bindgen-futures = { version = "0.4.29" }
+wasm-bindgen = { version = "= 0.2.79", features = ["serde-serialize"], optional = true }
+wasm-bindgen-futures = { version = "0.4.29", optional = true }
+
+[features]
+default = ["js-runtime"]
+js-runtime = ["js-sys", "wasm-bindgen", "wasm-bindgen-futures", "bundlr-contracts-shared/js-runtime"]
 
 [dev-dependencies]
 futures = "0.3.21"

--- a/validators/src/actions/epoch.rs
+++ b/validators/src/actions/epoch.rs
@@ -4,11 +4,12 @@ use bundlr_contracts_shared::TransactionId;
 use rand_xoshiro::rand_core::{RngCore, SeedableRng};
 use rand_xoshiro::Xoshiro256PlusPlus;
 
-use bundlr_contracts_shared::{
-    contract_utils::js_imports::{Block, Transaction},
-    Address,
-};
+use bundlr_contracts_shared::Address;
 
+#[cfg(feature = "js-runtime")]
+use bundlr_contracts_shared::contract_utils::js_imports::{Block, Transaction};
+
+#[cfg(feature = "js-runtime")]
 use crate::{
     action::ActionResult, contract_utils::handler_result::HandlerResult, error::ContractError,
     state::State,
@@ -59,6 +60,7 @@ where
     addresses
 }
 
+#[cfg(feature = "js-runtime")]
 pub async fn update_epoch(mut state: State) -> ActionResult {
     if (Block::height() as u128) <= state.epoch.height {
         return Err(ContractError::UpdateEpochBlocked);

--- a/validators/src/actions/join.rs
+++ b/validators/src/actions/join.rs
@@ -1,13 +1,19 @@
 use std::str::FromStr;
 
-use bundlr_contracts_shared::{
-    contract_utils::js_imports::{Contract, SmartWeave},
-    Address, Amount,
-};
+use bundlr_contracts_shared::{Address, Amount};
+
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "js-runtime")]
+use bundlr_contracts_shared::contract_utils::js_imports::{Contract, SmartWeave};
+
+#[cfg(feature = "js-runtime")]
 use url::Url;
+
+#[cfg(feature = "js-runtime")]
 use wasm_bindgen::JsValue;
 
+#[cfg(feature = "js-runtime")]
 use crate::{
     action::ActionResult,
     contract_utils::{handler_result::HandlerResult, js_imports::log},
@@ -29,6 +35,7 @@ struct Result {
     result_type: String,
 }
 
+#[cfg(feature = "js-runtime")]
 pub async fn join(mut state: State, stake: Amount, url: Url) -> ActionResult {
     let caller = SmartWeave::caller()
         .parse::<Address>()
@@ -57,7 +64,6 @@ pub async fn join(mut state: State, stake: Amount, url: Url) -> ActionResult {
     .await;
 
     log("AFTER TRANSFER");
-
 
     let result: Result = result.into_serde().unwrap();
     log(&format!("AFTER TRANSFER RESULT {:?}", result));

--- a/validators/src/actions/leave.rs
+++ b/validators/src/actions/leave.rs
@@ -1,7 +1,14 @@
-use bundlr_contracts_shared::{contract_utils::js_imports::SmartWeave, Address, Amount};
+use bundlr_contracts_shared::{Address, Amount};
+
 use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "js-runtime")]
+use bundlr_contracts_shared::contract_utils::js_imports::SmartWeave;
+
+#[cfg(feature = "js-runtime")]
 use wasm_bindgen::JsValue;
 
+#[cfg(feature = "js-runtime")]
 use crate::{
     action::ActionResult, contract_utils::handler_result::HandlerResult, error::ContractError,
     state::State,
@@ -20,6 +27,7 @@ struct Result {
     result_type: String,
 }
 
+#[cfg(feature = "js-runtime")]
 pub async fn leave(mut state: State) -> ActionResult {
     let caller = SmartWeave::caller()
         .parse::<Address>()

--- a/validators/src/actions/mod.rs
+++ b/validators/src/actions/mod.rs
@@ -5,6 +5,9 @@ mod leave;
 pub mod queries;
 pub mod slashing;
 
+#[cfg(feature = "js-runtime")]
 pub use epoch::update_epoch;
+#[cfg(feature = "js-runtime")]
 pub use join::join;
+#[cfg(feature = "js-runtime")]
 pub use leave::leave;

--- a/validators/src/contract.rs
+++ b/validators/src/contract.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "js-runtime")]
 use bundlr_contracts_shared::contract_utils::js_imports::{Block, SmartWeave, Transaction};
 use bundlr_contracts_shared::{Address, TransactionId};
 
@@ -6,6 +7,7 @@ use crate::actions;
 use crate::error::ContractError;
 use crate::state::State;
 
+#[cfg(feature = "js-runtime")]
 pub async fn handle(current_state: State, action: Action) -> ActionResult {
     let caller = SmartWeave::caller()
         .parse::<Address>()

--- a/validators/src/contract_utils/mod.rs
+++ b/validators/src/contract_utils/mod.rs
@@ -2,6 +2,8 @@
 /////////////// DO NOT MODIFY THIS FILE /////////////
 /////////////////////////////////////////////////////
 
+#[cfg(feature = "js-runtime")]
 pub mod entrypoint;
 pub mod handler_result;
+#[cfg(feature = "js-runtime")]
 pub mod js_imports;


### PR DESCRIPTION
Validator app depends on validators contracts, but only needs the
access to type definitions. Including wasm-bindgen creates dependency
conflict between validator app and validators contract when the version
of the wasm-bindgen requires too old version of chrono crate.

This change is a quick hack to allow validator app to depend on
validators contract crate without pulling wasm-bindgen as a dependency.

While we need better split of the code, this allows us to move forward
for now without more extensive restructure of the code.